### PR TITLE
Bind paramaters to query with pystache instead of str.format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['requests'],
+    install_requires=['requests', 'pystache'],
 
     test_suite = 'tests'
 )

--- a/tests/test_redash_dynamic_query.py
+++ b/tests/test_redash_dynamic_query.py
@@ -1,0 +1,29 @@
+import unittest
+
+from redash_dynamic_query import RedashDynamicQuery
+
+
+class TestRedashDynamicQuery(unittest.TestCase):
+    def test_bind_params(self):
+        redash = RedashDynamicQuery('', '', '')
+        bind = {'user_id': 123}
+
+        self.assertEqual(
+            redash._bind_params('SELECT * FROM users;', None),
+            'SELECT * FROM users;')
+        self.assertEqual(
+            redash._bind_params('SELECT * FROM users WHERE id={{user_id}};', bind),
+            'SELECT * FROM users WHERE id=123;')
+        self.assertEqual(
+            redash._bind_params('SELECT * FROM users WHERE id={{ user_id }};', bind),
+            'SELECT * FROM users WHERE id=123;')
+        self.assertEqual(
+            redash._bind_params('SELECT * FROM users WHERE id={{{user_id}}};', bind),
+            'SELECT * FROM users WHERE id=123;')
+        self.assertEqual(
+            redash._bind_params('SELECT id REGEXP \'^[0-9]{1,4}\' FROM users WHERE id={{user_id}};', bind),
+            'SELECT id REGEXP \'^[0-9]{1,4}\' FROM users WHERE id=123;')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi, @toritori0318 

I want to solve an issue related to non-parameter curly brace.
e.g. REGEXP() on MySQL or REGEXP_MATCH() on BigQuery and so on.

If you have any concerns, please feel free to let me know.
Thanks.